### PR TITLE
Create/Update PHPDocs for controllers

### DIFF
--- a/src/Http/Controllers/ActiveTasksController.php
+++ b/src/Http/Controllers/ActiveTasksController.php
@@ -22,6 +22,12 @@ class ActiveTasksController extends Controller
         $this->tasks = $tasks;
     }
 
+    /**
+     * Store a newly active task in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
     public function store(Request $request)
     {
         $task = $this->tasks->activate($request->all());
@@ -29,6 +35,12 @@ class ActiveTasksController extends Controller
         return response()->json($task, 200);
     }
 
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
     public function destroy($id)
     {
         $task = $this->tasks->deactivate($id);

--- a/src/Http/Controllers/DashboardController.php
+++ b/src/Http/Controllers/DashboardController.php
@@ -4,6 +4,11 @@ namespace Studio\Totem\Http\Controllers;
 
 class DashboardController extends Controller
 {
+    /**
+     * Single page application catch-all route.
+     *
+     * @return \Illuminate\Http\Response
+     */
     public function index()
     {
         return redirect()->route('totem.tasks.all');

--- a/src/Http/Controllers/ExecuteTasksController.php
+++ b/src/Http/Controllers/ExecuteTasksController.php
@@ -6,6 +6,11 @@ use Illuminate\Support\Facades\Artisan;
 
 class ExecuteTasksController extends Controller
 {
+    /**
+     * Execute a specific task.
+     *
+     * @return \Illuminate\Http\Response
+     */
     public function index($task)
     {
         $command = app($task->command);

--- a/src/Http/Controllers/TasksController.php
+++ b/src/Http/Controllers/TasksController.php
@@ -22,6 +22,7 @@ class TasksController extends Controller
 
     /**
      * TasksController constructor.
+     *
      * @param TaskInterface $tasks
      * @param Kernel $kernel
      */
@@ -34,6 +35,8 @@ class TasksController extends Controller
     }
 
     /**
+     * Display a listing of the tasks.
+     *
      * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
      */
     public function index()
@@ -44,6 +47,8 @@ class TasksController extends Controller
     }
 
     /**
+     * Show the form for creating a new task.
+     *
      * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
      */
     public function create()
@@ -57,6 +62,8 @@ class TasksController extends Controller
     }
 
     /**
+     * Store a newly created task in storage.
+     *
      * @param TaskRequest $request
      * @return \Illuminate\Http\RedirectResponse
      */
@@ -70,6 +77,8 @@ class TasksController extends Controller
     }
 
     /**
+     * Display the specified task.
+     *
      * @param $task
      * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
      */
@@ -81,6 +90,8 @@ class TasksController extends Controller
     }
 
     /**
+     * Show the form for editing the specified task.
+     *
      * @param $task
      * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
      */
@@ -95,6 +106,8 @@ class TasksController extends Controller
     }
 
     /**
+     * Update the specified task in storage.
+     *
      * @param TaskRequest $request
      * @param $task
      * @return \Illuminate\Http\RedirectResponse
@@ -109,6 +122,8 @@ class TasksController extends Controller
     }
 
     /**
+     * Remove the specified task from storage.
+     *
      * @param $task
      * @return \Illuminate\Http\RedirectResponse
      */


### PR DESCRIPTION
Taking for base the [Controller.stub](https://github.com/laravel/framework/blob/master/src/Illuminate/Routing/Console/stubs/controller.model.stub) from Laravel and the [HomeController](https://github.com/laravel/horizon/blob/master/src/Http/Controllers/HomeController.php) in Horizon, I've created some PHPDocs for the Laravel Totem Controllers :smile: 