### PR TITLE
Remove redundant parameter from loadMigrationsFrom 

### DIFF
--- a/src/Providers/TotemServiceProvider.php
+++ b/src/Providers/TotemServiceProvider.php
@@ -70,7 +70,7 @@ class TotemServiceProvider extends ServiceProvider
     protected function registerResources()
     {
         $this->loadViewsFrom(__DIR__.'/../../resources/views', 'totem');
-        $this->loadMigrationsFrom(__DIR__.'/../../database/migrations', 'totem');
+        $this->loadMigrationsFrom(__DIR__.'/../../database/migrations');
         $this->loadTranslationsFrom(__DIR__.'/../../resources/lang', 'totem');
     }
 


### PR DESCRIPTION
`loadMigrationsFrom` has only one parameter.